### PR TITLE
Checks that a new hunk has started on the current file

### DIFF
--- a/src/Parse/UnifiedDiffTokenizer.php
+++ b/src/Parse/UnifiedDiffTokenizer.php
@@ -116,6 +116,12 @@ final class UnifiedDiffTokenizer
             // Iterate until we have the correct number of original & new lines
             $lineCount = count($diffLineList);
             for ($i = $currentLine; $i < $lineCount; $i++) {
+                
+                // Start of new hunk on current file.
+                if ($i !== $currentLine && ('@' === substr($diffLineList[$i], 0, 1))) {
+                    break;
+                }
+                
                 $tokenList[] = $this->getHunkLineToken(
                     $addedCount,
                     $removedCount,


### PR DESCRIPTION
This will check wether or not a new hunk has started within the same file creating individual hunks per file.

example:
```
diff --git a/file_changed b/file_changed
index 4aa416a24..ad97c3f56 100644
--- a/file_changed
+++ b/file_changed
@@ -14 +13,0 @@ Start File Changed
-     Line that was removed
@@ -37,0 +37 @@ Start File Changed
+     Line that was added
@@ -49,0 +50,2 @@ Start File Changed
+      Line that was added
+      Line that was added
@@ -58,2 +60,2 @@ Start File Changed
-      Line that was removed
-      Line that was removed
+      Line that was added
+      Line that was added
```

This should return one file changed with 4 different hunks, but it currently returns one file changed with a hunk including all lines including the ones with `@@`