### PR TITLE
Fix handling of changes to single-line files

### DIFF
--- a/src/Parse/Token.php
+++ b/src/Parse/Token.php
@@ -16,13 +16,12 @@ final class Token
     public const ORIGINAL_FILENAME = 'original_filename';
     public const NEW_FILENAME = 'new_filename';
 
-    public const FILE_DELETION_LINE_COUNT = 'file_deletion';
-    public const FILE_CREATION_LINE_COUNT = 'file_creation';
-
     public const HUNK_ORIGINAL_START = 'hunk_original_start';
     public const HUNK_ORIGINAL_COUNT = 'hunk_original_count';
+    public const HUNK_ORIGINAL_ONE_LINE = 'hunk_original_one_line';
     public const HUNK_NEW_START = 'hunk_new_start';
     public const HUNK_NEW_COUNT = 'hunk_new_count';
+    public const HUNK_NEW_ONE_LINE = 'hunk_new_one_line';
 
     public const SOURCE_LINE_ADDED = 'source_line_added';
     public const SOURCE_LINE_REMOVED = 'source_line_removed';

--- a/tests/Integration/Parse/Git/DiffParserAddTest.php
+++ b/tests/Integration/Parse/Git/DiffParserAddTest.php
@@ -50,7 +50,7 @@ final class DiffParserAddTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            '',
+            '/dev/null',
             'README.md',
             File::CREATED,
             [

--- a/tests/Integration/Parse/Git/DiffParserSingleLineFileTest.php
+++ b/tests/Integration/Parse/Git/DiffParserSingleLineFileTest.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
 /**
- * @copyright (c) 2014-present brian ridley
- * @author brian ridley <ptlis@ptlis.net>
  * @license http://opensource.org/licenses/MIT MIT
  */
 
@@ -16,7 +14,7 @@ use ptlis\DiffParser\Parse\UnifiedDiffParser;
 use ptlis\DiffParser\Parse\UnifiedDiffTokenizer;
 use ptlis\DiffParser\Parse\GitDiffNormalizer;
 
-final class DiffParserRemoveTest extends TestCase
+final class DiffParserSingleLineFileTest extends TestCase
 {
     public function testParseCount(): void
     {
@@ -26,7 +24,7 @@ final class DiffParserRemoveTest extends TestCase
             )
         );
 
-        $data = file_get_contents(__DIR__ . '/data/diff_remove');
+        $data = file_get_contents(__DIR__ . '/data/diff_single_line_file');
 
         $diff = $parser->parse($data);
 
@@ -34,7 +32,7 @@ final class DiffParserRemoveTest extends TestCase
         $this->assertEquals(1, count($diff->getFiles()));
     }
 
-    public function testFileRemove(): void
+    public function testFileEdited(): void
     {
         $parser = new UnifiedDiffParser(
             new UnifiedDiffTokenizer(
@@ -42,7 +40,7 @@ final class DiffParserRemoveTest extends TestCase
             )
         );
 
-        $data = file_get_contents(__DIR__ . '/data/diff_remove');
+        $data = file_get_contents(__DIR__ . '/data/diff_single_line_file');
 
         $diff = $parser->parse($data);
         $fileList = $diff->getFiles();
@@ -50,18 +48,19 @@ final class DiffParserRemoveTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            'README.md',
-            '/dev/null',
-            File::DELETED,
+            'test.txt',
+            'test.txt',
+            File::CHANGED,
             [
                 new Hunk(
                     1,
                     1,
-                    0,
-                    0,
+                    1,
+                    1,
                     "\n",
                     [
-                        new Line(1, -1, Line::REMOVED, '# My project', '')
+                        new Line(1, -1, Line::REMOVED, 'test', "\n"),
+                        new Line(-1, 1, Line::ADDED, 'edited', "\n")
                     ]
                 )
             ]

--- a/tests/Integration/Parse/Git/DiffTokenizerAddTest.php
+++ b/tests/Integration/Parse/Git/DiffTokenizerAddTest.php
@@ -25,12 +25,12 @@ final class DiffTokenizerAddTest extends TestCase
 
         $this->assertEquals(7, count($tokenList));
 
-        $this->assertEquals(new Token(Token::ORIGINAL_FILENAME, '', "\n"), $tokenList[0]);
+        $this->assertEquals(new Token(Token::ORIGINAL_FILENAME, '/dev/null', "\n"), $tokenList[0]);
         $this->assertEquals(new Token(Token::NEW_FILENAME, 'README.md', "\n"), $tokenList[1]);
 
         $this->assertEquals(new Token(Token::HUNK_ORIGINAL_START, '0', ''), $tokenList[2]);
         $this->assertEquals(new Token(Token::HUNK_ORIGINAL_COUNT, '0', ''), $tokenList[3]);
-        $this->assertEquals(new Token(Token::FILE_CREATION_LINE_COUNT, '1', "\n"), $tokenList[4]);
+        $this->assertEquals(new Token(Token::HUNK_NEW_ONE_LINE, '1', "\n"), $tokenList[4]);
 
         $this->assertEquals(new Token(Token::SOURCE_LINE_ADDED, '## Test', "\n"), $tokenList[5]);
         $this->assertEquals(new Token(Token::SOURCE_NO_NEWLINE_EOF, '\ No newline at end of file', ''), $tokenList[6]);

--- a/tests/Integration/Parse/Git/DiffTokenizerRemoveTest.php
+++ b/tests/Integration/Parse/Git/DiffTokenizerRemoveTest.php
@@ -26,9 +26,9 @@ final class DiffTokenizerRemoveTest extends TestCase
         $this->assertEquals(7, count($tokenList));
 
         $this->assertEquals(new Token(Token::ORIGINAL_FILENAME, 'README.md', "\n"), $tokenList[0]);
-        $this->assertEquals(new Token(Token::NEW_FILENAME, '', "\n"), $tokenList[1]);
+        $this->assertEquals(new Token(Token::NEW_FILENAME, '/dev/null', "\n"), $tokenList[1]);
 
-        $this->assertEquals(new Token(Token::FILE_DELETION_LINE_COUNT, '1', ''), $tokenList[2]);
+        $this->assertEquals(new Token(Token::HUNK_ORIGINAL_ONE_LINE, '1', ''), $tokenList[2]);
         $this->assertEquals(new Token(Token::HUNK_NEW_START, '0', ''), $tokenList[3]);
         $this->assertEquals(new Token(Token::HUNK_NEW_COUNT, '0', "\n"), $tokenList[4]);
 

--- a/tests/Integration/Parse/Git/data/diff_single_line_file
+++ b/tests/Integration/Parse/Git/data/diff_single_line_file
@@ -1,0 +1,7 @@
+diff --git a/test.txt b/test.txt
+index 9daeafb..7663aa7 100644
+--- a/test.txt
++++ b/test.txt
+@@ -1 +1 @@
+-test
++edited

--- a/tests/Integration/Parse/Svn/DiffParserAddTest.php
+++ b/tests/Integration/Parse/Svn/DiffParserAddTest.php
@@ -50,7 +50,7 @@ final class DiffParserAddTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            '',
+            'README.md',
             'README.md',
             File::CREATED,
             [

--- a/tests/Integration/Parse/Svn/DiffParserMalformedFilenamesTest.php
+++ b/tests/Integration/Parse/Svn/DiffParserMalformedFilenamesTest.php
@@ -50,7 +50,7 @@ final class DiffParserMalformedFilenamesTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            '',
+            'README.md',
             'README.md',
             File::CREATED,
             [

--- a/tests/Integration/Parse/Svn/DiffParserRemoveTest.php
+++ b/tests/Integration/Parse/Svn/DiffParserRemoveTest.php
@@ -51,7 +51,7 @@ final class DiffParserRemoveTest extends TestCase
 
         $file = new File(
             'README.md',
-            '',
+            'README.md',
             File::DELETED,
             [
                 new Hunk(

--- a/tests/Integration/Parse/Svn/DiffParserSingleLineFileTest.php
+++ b/tests/Integration/Parse/Svn/DiffParserSingleLineFileTest.php
@@ -1,12 +1,10 @@
 <?php declare(strict_types=1);
 
 /**
- * @copyright (c) 2014-present brian ridley
- * @author brian ridley <ptlis@ptlis.net>
  * @license http://opensource.org/licenses/MIT MIT
  */
 
-namespace ptlis\DiffParser\Integration\Test\Parse\Git;
+namespace ptlis\DiffParser\Test\Integration\Parse\Svn;
 
 use PHPUnit\Framework\TestCase;
 use ptlis\DiffParser\File;
@@ -14,19 +12,19 @@ use ptlis\DiffParser\Hunk;
 use ptlis\DiffParser\Line;
 use ptlis\DiffParser\Parse\UnifiedDiffParser;
 use ptlis\DiffParser\Parse\UnifiedDiffTokenizer;
-use ptlis\DiffParser\Parse\GitDiffNormalizer;
+use ptlis\DiffParser\Parse\SvnDiffNormalizer;
 
-final class DiffParserRemoveTest extends TestCase
+final class DiffParserSingleLineFileTest extends TestCase
 {
     public function testParseCount(): void
     {
         $parser = new UnifiedDiffParser(
             new UnifiedDiffTokenizer(
-                new GitDiffNormalizer()
+                new SvnDiffNormalizer()
             )
         );
 
-        $data = file_get_contents(__DIR__ . '/data/diff_remove');
+        $data = file_get_contents(__DIR__ . '/data/diff_single_line_file');
 
         $diff = $parser->parse($data);
 
@@ -34,15 +32,15 @@ final class DiffParserRemoveTest extends TestCase
         $this->assertEquals(1, count($diff->getFiles()));
     }
 
-    public function testFileRemove(): void
+    public function testFileEdited(): void
     {
         $parser = new UnifiedDiffParser(
             new UnifiedDiffTokenizer(
-                new GitDiffNormalizer()
+                new SvnDiffNormalizer()
             )
         );
 
-        $data = file_get_contents(__DIR__ . '/data/diff_remove');
+        $data = file_get_contents(__DIR__ . '/data/diff_single_line_file');
 
         $diff = $parser->parse($data);
         $fileList = $diff->getFiles();
@@ -50,18 +48,19 @@ final class DiffParserRemoveTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            'README.md',
-            '/dev/null',
-            File::DELETED,
+            'test.txt',
+            'test.txt',
+            File::CHANGED,
             [
                 new Hunk(
                     1,
                     1,
-                    0,
-                    0,
+                    1,
+                    1,
                     "\n",
                     [
-                        new Line(1, -1, Line::REMOVED, '# My project', '')
+                        new Line(1, -1, Line::REMOVED, 'test', "\n"),
+                        new Line(-1, 1, Line::ADDED, 'edited', "\n")
                     ]
                 )
             ]

--- a/tests/Integration/Parse/Svn/DiffTokenizerAddTest.php
+++ b/tests/Integration/Parse/Svn/DiffTokenizerAddTest.php
@@ -25,12 +25,12 @@ final class DiffTokenizerAddTest extends TestCase
 
         $this->assertEquals(7, count($tokenList));
 
-        $this->assertEquals(new Token(Token::ORIGINAL_FILENAME, '', "\n"), $tokenList[0]);
+        $this->assertEquals(new Token(Token::ORIGINAL_FILENAME, 'README.md', "\n"), $tokenList[0]);
         $this->assertEquals(new Token(Token::NEW_FILENAME, 'README.md', "\n"), $tokenList[1]);
 
         $this->assertEquals(new Token(Token::HUNK_ORIGINAL_START, '0', ''), $tokenList[2]);
         $this->assertEquals(new Token(Token::HUNK_ORIGINAL_COUNT, '0', ''), $tokenList[3]);
-        $this->assertEquals(new Token(Token::FILE_CREATION_LINE_COUNT, '1', "\n"), $tokenList[4]);
+        $this->assertEquals(new Token(Token::HUNK_NEW_ONE_LINE, '1', "\n"), $tokenList[4]);
 
         $this->assertEquals(new Token(Token::SOURCE_LINE_ADDED, '## Test', "\n"), $tokenList[5]);
         $this->assertEquals(new Token(Token::SOURCE_NO_NEWLINE_EOF, '\ No newline at end of file', ''), $tokenList[6]);

--- a/tests/Integration/Parse/Svn/DiffTokenizerRemoveTest.php
+++ b/tests/Integration/Parse/Svn/DiffTokenizerRemoveTest.php
@@ -26,9 +26,9 @@ final class DiffTokenizerRemoveTest extends TestCase
         $this->assertEquals(7, count($tokenList));
 
         $this->assertEquals(new Token(Token::ORIGINAL_FILENAME, 'README.md', "\n"), $tokenList[0]);
-        $this->assertEquals(new Token(Token::NEW_FILENAME, '', "\n"), $tokenList[1]);
+        $this->assertEquals(new Token(Token::NEW_FILENAME, 'README.md', "\n"), $tokenList[1]);
 
-        $this->assertEquals(new Token(Token::FILE_DELETION_LINE_COUNT, '1', ''), $tokenList[2]);
+        $this->assertEquals(new Token(Token::HUNK_ORIGINAL_ONE_LINE, '1', ''), $tokenList[2]);
         $this->assertEquals(new Token(Token::HUNK_NEW_START, '0', ''), $tokenList[3]);
         $this->assertEquals(new Token(Token::HUNK_NEW_COUNT, '0', "\n"), $tokenList[4]);
 

--- a/tests/Integration/Parse/Svn/data/diff_single_line_file
+++ b/tests/Integration/Parse/Svn/data/diff_single_line_file
@@ -1,0 +1,7 @@
+Index: test.txt
+===================================================================
+--- test.txt	(revision 2)
++++ test.txt	(revision 3)
+@@ -1 +1 @@
+-test
++edited

--- a/tests/Integration/ParserTest.php
+++ b/tests/Integration/ParserTest.php
@@ -31,7 +31,7 @@ final class ParserTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            '',
+            '/dev/null',
             'README.md',
             File::CREATED,
             [
@@ -63,7 +63,7 @@ final class ParserTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            '',
+            'README.md',
             'README.md',
             File::CREATED,
             [
@@ -95,7 +95,7 @@ final class ParserTest extends TestCase
         $this->assertEquals(1, count($fileList[0]->getHunks()));
 
         $file = new File(
-            '',
+            '/dev/null',
             'README.md',
             File::CREATED,
             [


### PR DESCRIPTION
For some reason the syntax for a change to a single-line file was
conflated with the syntax for adding or deleting a file. This caused a
diff like
```diff
diff --git a/.nvmrc b/.nvmrc
--- a/.nvmrc
+++ b/.nvmrc
@@ -1 +1 @@
-14.16.1
+16.7.0
```
to be interpreted as deleting the file rather than changing it.

Fixing that involves deleting the erroneous constants
FILE_DELETION_LINE_COUNT and FILE_CREATION_LINE_COUNT, and changing all
the logic that used them to correctly interpret their replacements.

I note the logic here still isn't quite correct, as it does not
differentiate between a file that is deleted and one that is truncated
to 0 bytes, or one that is created and one that was formerly 0 bytes.
I'll leave that for someone else to figure out; it seems the general
answer is to look at the timestamp, but svn doesn't output any
timestamps.

I also noted that the behavior with respect to filenames reported for
added and deleted files was inconsistent: if the file had multiple
lines the original and new name in the diff header was reported, while
if it had a single line the unnecessary name was omitted. This PR makes
it consistently use the former behavior, as that seems like the most
common case that users of the library would have encountered.